### PR TITLE
修复烛状图不能自适应高度的bug

### DIFF
--- a/klinelib/src/main/java/com/icechao/klinelib/base/BaseKChartView.java
+++ b/klinelib/src/main/java/com/icechao/klinelib/base/BaseKChartView.java
@@ -1796,17 +1796,27 @@ public abstract class BaseKChartView extends ScrollAndScaleView {
     }
 
     protected void calcMainMaxValue(int tempIndex) {
-        mainMaxValue = (mainStatus == Status.MAIN_MA || mainStatus == Status.MAIN_NONE) ?
-                mainRender.getMaxValue((float) mainMaxValue,
+        switch (mainStatus){
+            case Status.MAIN_MA:
+                mainMaxValue = mainRender.getMaxValue((float) mainMaxValue,
                         points[tempIndex + Constants.INDEX_HIGH],
                         points[tempIndex + Constants.INDEX_MA_1],
                         points[tempIndex + Constants.INDEX_MA_2],
-                        points[tempIndex + Constants.INDEX_MA_3]) :
-                mainRender.getMaxValue((float) mainMaxValue,
+                        points[tempIndex + Constants.INDEX_MA_3]);
+                break;
+            case Status.MAIN_BOLL:
+                mainMaxValue = mainRender.getMaxValue((float) mainMaxValue,
                         points[tempIndex + Constants.INDEX_HIGH],
                         points[tempIndex + Constants.INDEX_BOLL_DN],
                         points[tempIndex + Constants.INDEX_BOLL_UP],
                         points[tempIndex + Constants.INDEX_BOLL_MB]);
+                break;
+            default:
+                mainMaxValue = mainRender.getMaxValue((float) mainMaxValue,
+                        points[tempIndex + Constants.INDEX_HIGH]);
+                break;
+        }
+
     }
 
     /**


### PR DESCRIPTION
当主图没有设置任何指标，当前k线没有自适应高度，这里只需要取 当前屏幕的最大值 high 值就可以
如果设置了指标，就把对应指标的对应最大值求出来即可